### PR TITLE
ChButton [Fix]: Удалил фиксированную ширину

### DIFF
--- a/src/components/ChButton/ChButton.vue
+++ b/src/components/ChButton/ChButton.vue
@@ -48,6 +48,8 @@ export default defineComponent({
 
 <style lang="sass" scoped>
 .ch-button
+  --ch-button-border-width: 1px
+
   font-style: normal
   font-weight: 900
   font-size: 24px
@@ -79,7 +81,7 @@ export default defineComponent({
     color: var(--color-primary-text)
 
   &_bordered
-    border: 1px solid var(--color-secondary-dark)
+    border: var(--ch-button-border-width, 1px) solid var(--color-secondary-dark)
     background: transparent
     color: var(--color-primary-text)
 

--- a/src/components/ChButton/ChButton.vue
+++ b/src/components/ChButton/ChButton.vue
@@ -26,7 +26,7 @@
 
 <script setup lang="ts">
 type SizeType = 'md' | 'sm' | 'xs'
-type ShapeType = 'circle' | 'flexible'
+type ShapeType = 'circle'
 
 defineProps<{
   size?: SizeType
@@ -62,7 +62,6 @@ export default defineComponent({
   border-radius: 16px
   border: none
   padding: 16px
-  width: 180px
   cursor: pointer
 
   &__prepend
@@ -106,9 +105,6 @@ export default defineComponent({
     font-weight: 400
     font-size: 16px
     line-height: 18px
-
-  &_shape_flexible
-    width: auto
 
   &_shape_circle
     padding: 8px


### PR DESCRIPTION
### Проблема
- В стилях у компонента ChButton была прописана фиксированная ширина `180px` и из-за этого сложно использовать `ChButton` в проекте, т.к каждый раз приходится либо проставлять `shape="flexible" либо `width: ... !important`
- У `ChButton` фиксированная ширина рамки и для ее изменения приходится использовать `!important`

### Решение
- Удалил стили, которые задавали фиксированную ширину для кнопки и `flexible` логику, т.к в ней больше нет смысла
- Добавил css переменную для изменения ширины рамки