### PR TITLE
ChSlider - expose slideAPI instance

### DIFF
--- a/src/components/ChSlider/ChSlider.spec.ts
+++ b/src/components/ChSlider/ChSlider.spec.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import { shallowMount } from '@vue/test-utils'
+
 import { findByTestId } from '@/__test__/utils'
 import ChSlider from './ChSlider.vue'
-
 import type { VueWrapper } from '@vue/test-utils'
 import type { Options } from 'nouislider'
 
@@ -39,8 +39,36 @@ describe('ChSlider', () => {
     expect(parseInt(upperLabel.text())).toBe(RANGE.max[0])
   })
 
-  it('should expose sliderAPI object', () => {
+  it('should expose sliderAPI object of type noUiSlider.API', () => {
     const wrapper = shallowMount(ChSlider)
     expect(wrapper.vm.sliderAPI).toBeTruthy()
+    expect(wrapper.vm.sliderAPI).toMatchInlineSnapshot(
+      {
+        target: expect.any(HTMLElement),
+        options: expect.any(Object)
+      },
+      `
+        {
+          "__moveHandles": [Function],
+          "destroy": [Function],
+          "get": [Function],
+          "getOrigins": [Function],
+          "getPositions": [Function],
+          "getTooltips": [Function],
+          "off": [Function],
+          "on": [Function],
+          "options": Any<Object>,
+          "pips": [Function],
+          "removePips": [Function],
+          "removeTooltips": [Function],
+          "reset": [Function],
+          "set": [Function],
+          "setHandle": [Function],
+          "steps": [Function],
+          "target": Any<HTMLElement>,
+          "updateOptions": [Function],
+        }
+      `
+    )
   })
 })

--- a/src/components/ChSlider/ChSlider.spec.ts
+++ b/src/components/ChSlider/ChSlider.spec.ts
@@ -38,4 +38,9 @@ describe('ChSlider', () => {
     expect(parseInt(lowerLabel.text())).toBe(RANGE.min[0])
     expect(parseInt(upperLabel.text())).toBe(RANGE.max[0])
   })
+
+  it('should expose sliderAPI object', () => {
+    const wrapper = shallowMount(ChSlider)
+    expect(wrapper.vm.sliderAPI).toBeTruthy()
+  })
 })

--- a/src/components/ChSlider/ChSlider.vue
+++ b/src/components/ChSlider/ChSlider.vue
@@ -13,7 +13,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import noUiSlider from 'nouislider'
-import type { Options, target } from 'nouislider'
+import type { Options, target, API } from 'nouislider'
 import type { PropType } from 'vue'
 
 const emit = defineEmits(['change:modelValue', 'update:modelValue'])
@@ -38,21 +38,26 @@ const props = defineProps({
 
 const sliderBody = ref<target>({} as target)
 const sliderLabels = ref<(number | string)[]>([])
+const sliderAPI = ref<API>()
 
 onMounted(() => {
-  noUiSlider.create(sliderBody.value, {
+  sliderAPI.value = noUiSlider.create(sliderBody.value, {
     cssPrefix: 'ch-slider__',
     ...props.configs
   })
 
-  sliderBody.value.noUiSlider?.on('update', function (values) {
+  sliderAPI.value.on('update', function (values) {
     sliderLabels.value = values
     emit('change:modelValue', values)
   })
 
-  sliderBody.value.noUiSlider?.on('end', function (values) {
+  sliderAPI.value.on('end', function (values) {
     emit('update:modelValue', values)
   })
+})
+
+defineExpose({
+  sliderAPI
 })
 </script>
 


### PR DESCRIPTION
## ChSlider 

### Проблема

- Состояние слайдера не синхронизируется со внешним состоянием. Есть случаи, когда нужно сбросить внешнее состоянии и UI слайдера тоже должен обновиться. Но UI не обновляется

### Решение:
- Добавил expose sliderAPI для того, чтобы можно было использовать api в родительских компонентах для более гибкого управления UI
- Добавил тест для проверки публичного api ChSlider