### PR TITLE
Удаляем все блокираторы скрола при переходе на другую страницу

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "choco-ui",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "choco-ui",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-regular-svg-icons": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-ui",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "files": [
     "dist"
   ],

--- a/src/components/ChBottomSheet/ChBottomSheet.vue
+++ b/src/components/ChBottomSheet/ChBottomSheet.vue
@@ -93,7 +93,7 @@ if (controller) {
   })
 }
 
-onBeforeUnmount(() => controller?.hide(props.name))
+onBeforeUnmount(() => controller?.onDestroy(props.name))
 
 const onBlackoutTouchStart = () => (bottomSheetState.value.blackoutTouchStarted = true)
 

--- a/src/composable/modal-bottom-sheet-controller/use-modal-bottom-sheet-controller.ts
+++ b/src/composable/modal-bottom-sheet-controller/use-modal-bottom-sheet-controller.ts
@@ -1,6 +1,6 @@
 import { ref, readonly, nextTick } from 'vue'
 import type { Ref } from 'vue'
-import { lockScroll, unlockScroll } from './utils/scroll-lock'
+import { lockScroll, unlockScroll, clearAllLocks } from './utils/scroll-lock'
 
 export type ModalBottomSheet = {
   activeName: string
@@ -50,11 +50,17 @@ export function useModalBottomSheetController() {
     state.value = state.value.filter(modal => modal.activeName !== name)
   }
 
+  function onDestroy(name: string) {
+    clearAllLocks()
+    state.value = state.value.filter(modal => modal.activeName !== name)
+  }
+
   return {
     show,
     isVisible,
     getParams,
     hide,
+    onDestroy,
     state: readonly<Ref<ModalBottomSheet[]>>(state)
   }
 }

--- a/src/composable/modal-bottom-sheet-controller/utils/scroll-lock.ts
+++ b/src/composable/modal-bottom-sheet-controller/utils/scroll-lock.ts
@@ -1,4 +1,4 @@
-import { lock, unlock } from 'tua-body-scroll-lock'
+import { lock, unlock, clearBodyLocks } from 'tua-body-scroll-lock'
 
 /**
  * Returns element that should preserve scroll while all other components' scroll is locked
@@ -8,3 +8,4 @@ const getNode = (name: string): HTMLElement | null =>
 
 export const lockScroll = (scrollableElemName: string) => lock(getNode(scrollableElemName))
 export const unlockScroll = (scrollableElemName: string) => unlock(getNode(scrollableElemName))
+export const clearAllLocks = () => clearBodyLocks()


### PR DESCRIPTION
В документации не рекомендуется несколько раз закрывать один и тот же лок, для это есть clearBodyLocks https://github.com/tuax/tua-body-scroll-lock. Возможно именно из-за этого у нас возникают ошибки. Добавила эту функцию очистки на onBeforeUnmount компонента