### PR TITLE
ChSearchInput: Слот для контента cancel button и небольшой рефакторинг внутренней логики

### DIFF
--- a/src/components/ChSearchInput/ChSearchInput.spec.ts
+++ b/src/components/ChSearchInput/ChSearchInput.spec.ts
@@ -15,9 +15,10 @@ describe('ChSearchInput', () => {
         placeholder: 'Поиск'
       },
       slots: {
-        prepend: `<template #prepend>prepend</template>`,
-        append: `<template #append>append</template>`,
-        clearButton: `<template #clearButton>clearButton</template>`
+        prepend: 'prepend',
+        append: 'append',
+        clearButton: 'clearButton',
+        cancelButtonContent: 'Cancel'
       }
     }) as VueWrapper
   })
@@ -65,5 +66,9 @@ describe('ChSearchInput', () => {
     expect(SearchInput?.html()).toContain('prepend')
     expect(SearchInput?.html()).toContain('append')
     expect(SearchInput?.html()).toContain('clearButton')
+
+    findByTestId(SearchInput as VueWrapper, 'ch-input-input-component').trigger('focus')
+    await SearchInput?.vm.$nextTick()
+    expect(SearchInput?.html()).toContain('Cancel')
   })
 })

--- a/src/components/ChSearchInput/ChSearchInput.stories.mdx
+++ b/src/components/ChSearchInput/ChSearchInput.stories.mdx
@@ -24,6 +24,9 @@ import { Meta } from '@storybook/addon-docs'
       <template #clearButton>
         <fa-icon :icon="['fas', 'xmark']" />
       </template>
+      <template #cancelButtonContent>
+        Cancel text
+      </template>
     </ChSearchInput>
   </div>
 <template>
@@ -67,11 +70,12 @@ import { Meta } from '@storybook/addon-docs'
 
 #### Slots
 
-| Название          | Описание                                                                |
-|-------------------|-------------------------------------------------------------------------|
-| prepend           | Слот перед вводом, например иконка поиска                               |
-| append            | Слот после ввода                                                        |
-| clearButton       | Слот для иконки кнопки удаления, по умолчанию будет крестик из fa-icon  |
+| Название            | Описание                                                                |
+|---------------------|-------------------------------------------------------------------------|
+| prepend             | Слот перед вводом, например иконка поиска                               |
+| append              | Слот после ввода                                                        |
+| clearButton         | Слот для иконки кнопки удаления, по умолчанию будет крестик из fa-icon  |
+| cancelButtonContent | Слот для текста кнопки отмены                                           |
 
 
 

--- a/src/components/ChSearchInput/ChSearchInput.vue
+++ b/src/components/ChSearchInput/ChSearchInput.vue
@@ -7,8 +7,8 @@
       clearable
       class="ch-search-input__input"
       @update:modelValue="emit('onInput', $event)"
-      @focus="onFocus"
-      @blur="onBlur"
+      @focus="() => setCancelButtonVisibility(true)"
+      @blur="() => setCancelButtonVisibility(false)"
     >
       <template #prepend v-if="Boolean($slots.prepend)">
         <slot name="prepend" />
@@ -22,15 +22,20 @@
     </ChInput>
     <Transition name="cancel-button-leave">
       <ChButton
-        v-if="isVisibleCancelButton"
+        v-if="isCancelButtonVisible"
         type="button"
         size="xs"
         simple
         data-test-id="cancel-button"
         class="ch-search-input__button"
-        @click="onCancel"
+        @click="
+          () => {
+            setCancelButtonVisibility(false)
+            emit('onCancel')
+          }
+        "
       >
-        Отмена
+        <slot name="cancelButtonContent">Отмена</slot>
       </ChButton>
     </Transition>
   </div>
@@ -59,18 +64,9 @@ const emit = defineEmits<{
   (e: 'onInput', value: string): void
   (e: 'onCancel'): void
 }>()
-const isVisibleCancelButton = ref(false)
 
-function onFocus() {
-  isVisibleCancelButton.value = true
-}
-function onBlur() {
-  isVisibleCancelButton.value = false
-}
-function onCancel() {
-  isVisibleCancelButton.value = false
-  emit('onCancel')
-}
+const isCancelButtonVisible = ref(false)
+const setCancelButtonVisibility = (isVisible: boolean) => (isCancelButtonVisible.value = isVisible)
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
## ChSearchInput

- Добавили слот для контента cancel button, чтобы можно было прокидывать любую строку (локализация, например)
- Обновили документацию и тесты
- Упростили внутреннюю логику без изменения функционала

@raiymbekB @a-baktybay 