### PR TITLE
fix(ChBottomSheet): avoid overflowing native navigation buttons

### DIFF
--- a/src/components/ChBottomSheet/ChBottomSheet.vue
+++ b/src/components/ChBottomSheet/ChBottomSheet.vue
@@ -204,7 +204,7 @@ export default defineComponent({
   bottom: 0
   display: flex
   width: 100%
-  max-height: 95%
+  max-height: calc(100% - 60px) // optimal value to avoid collision with native navigation buttons
 
   &__content
     position: relative


### PR DESCRIPTION
- поменял максимальную высоту ChBottomSheet, чтобы не налазила не нативные навигационные кнопки

@KirIIISolovyov @a-baktybay 