### PR TITLE
ChAlert: allow to pass content in show method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "choco-ui",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "choco-ui",
-      "version": "0.11.3",
+      "version": "0.12.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-regular-svg-icons": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-ui",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "files": [
     "dist"
   ],

--- a/src/components/ChAlert/ChAlert.spec.ts
+++ b/src/components/ChAlert/ChAlert.spec.ts
@@ -79,7 +79,7 @@ describe('ChAlert', () => {
     expect(findByTestId(wrapper, 'alert-content').exists()).toBe(false)
   })
 
-  it('should display deafult slot content', async () => {
+  it('should display default slot content', async () => {
     const wrapper = getWrapper()
     wrapper.vm.show()
     await wrapper.vm.$nextTick()
@@ -98,5 +98,28 @@ describe('ChAlert', () => {
     wrapper.vm.show()
     await wrapper.vm.$nextTick()
     expect(wrapper.html()).toContain(footerSlotContent)
+  })
+
+  it('should display content passed to show method', async () => {
+    const wrapper = mount(ChAlert, {
+      slots: {
+        icon: `<template #icon="{ content }">{{ content.icon }}</template>`,
+        default: `<template #default="{ content }">{{ content.main }}</template>`,
+        footer: `<template #footer="{ content }">{{ content.footer }}</template>`
+      }
+    })
+
+    const showContent = {
+      main: 'Main content',
+      icon: 'Icon content',
+      footer: 'Footer content'
+    }
+
+    wrapper.vm.show(showContent)
+    await wrapper.vm.$nextTick()
+    const alertHtml = wrapper.html()
+    expect(alertHtml).toContain(showContent.main)
+    expect(alertHtml).toContain(showContent.icon)
+    expect(alertHtml).toContain(showContent.footer)
   })
 })

--- a/src/components/ChAlert/ChAlert.stories.js
+++ b/src/components/ChAlert/ChAlert.stories.js
@@ -19,8 +19,8 @@ const Template = (args, { parameters }) => ({
     return { args, parameters, alertRef }
   },
   methods: {
-    showAlert() {
-      this.alertRef.show()
+    showAlert(content) {
+      this.alertRef.show(content)
     },
     hideAlert() {
       this.alertRef.hide()
@@ -28,7 +28,7 @@ const Template = (args, { parameters }) => ({
   },
   template: `
     <div>
-      <button type="button" @click="showAlert">
+      <button type="button" @click="showAlert(parameters.alertContent)">
         Show alert
       </button>
       <button 
@@ -39,12 +39,14 @@ const Template = (args, { parameters }) => ({
         Hide alert
       </button>
       <div style="position: relative; margin-top: 20px;">
-        <ChAlert 
+        <ChAlert
           v-bind="args"
           ref="alertRef" 
           style="width: 300px"
         >
-          {{ parameters.content || 'Hello, ChAlert!' }}
+          <template #default="{ content }">
+            {{ content || parameters.content || 'Hello, ChAlert!' }}
+          </template>
           <template #icon>
             <ChAlertIcon>
               <fa-icon :icon="['fas', 'user']" />
@@ -81,4 +83,9 @@ Persistent.args = {
 export const WithFooter = Template.bind({})
 WithFooter.parameters = {
   withFooter: true
+}
+
+export const PassAlertContentInShow = Template.bind({})
+PassAlertContentInShow.parameters = {
+  alertContent: 'This text is passed via show method!'
 }

--- a/src/components/ChAlert/ChAlert.stories.mdx
+++ b/src/components/ChAlert/ChAlert.stories.mdx
@@ -10,8 +10,14 @@ import { Meta } from '@storybook/addon-docs';
 
 ```html
 <template>
-  <ChAlert ref="alertRef" duration="5000" persistent>
-    <p>Alert content</p>
+  <ChAlert
+    ref="alertRef"
+    duration="5000"
+    persistent
+  >
+    <template #default="{ content }">
+      <p>{{ content }}</p>
+    </template>
     <template #icon>
       <ChAlertIcon>Icon</ChAlertIcon>
     </template>
@@ -27,7 +33,7 @@ import { Meta } from '@storybook/addon-docs';
 
   const alertRef = ref()
 
-  alertRef.show() // Shows alert
+  alertRef.show('Alert content') // Shows alert with content == 'Alert content'
   alertRef.hide() // Hides alert
 </script>
 ```
@@ -56,15 +62,15 @@ ChAlert предоставляет public методы `show`, `hide` и пер�
 
   const alertRef = ref()
 
-  alertRef.show() // Shows alert
+  alertRef.show({ text: 'Content may be of any type' }) // Shows alert
   alertRef.hide() // Hides alert
 </script>
 ```
-| Название      | Тип                 | Описание                                                                |
-|---------------|---------------------|-------------------------------------------------------------------------|
-| show          | Function            | Метод для отображения алерта                                            |
-| hide          | Function            | Метод для закрытия    алерта                                            |
-| isVisible     | Readonly<`Boolean`> | Возвращает открыт ли алерт или нет                                      |
+| Название      | Тип                 | Описание                                                                                              |
+|---------------|---------------------|-------------------------------------------------------------------------------------------------------|
+| show          | Function            | Метод для отображения алерта. Может быть вызван с параметрами, которые будут записаны в поле content  |
+| hide          | Function            | Метод для закрытия    алерта                                                                          |
+| isVisible     | Readonly<`Boolean`> | Возвращает открыт ли алерт или нет                                                                    |
 
 ### Slots
 

--- a/src/components/ChAlert/ChAlert.stories.mdx
+++ b/src/components/ChAlert/ChAlert.stories.mdx
@@ -53,7 +53,14 @@ ChAlert предоставляет public методы `show`, `hide` и пер�
 
 ```html
 <template>
-  <ChAlert ref="alertRef"></ChAlert>
+  <ChAlert ref="alertRef">
+    <template #default="{ content }">
+      <p>{{ content.main }}</p>
+    </template>
+    <template #footer="{ content }">
+      <p>{{ content.footer }}</p>
+    </template>
+  </ChAlert>
 </template>
 
 <script>
@@ -62,7 +69,7 @@ ChAlert предоставляет public методы `show`, `hide` и пер�
 
   const alertRef = ref()
 
-  alertRef.show({ text: 'Content may be of any type' }) // Shows alert
+  alertRef.show({ main: 'Content may be of any type', footer: 'This is footer content' }) // Shows alert
   alertRef.hide() // Hides alert
 </script>
 ```

--- a/src/components/ChAlert/ChAlert.vue
+++ b/src/components/ChAlert/ChAlert.vue
@@ -3,12 +3,12 @@
     <div v-if="isVisible" class="ch-alert" data-test-id="alert-content">
       <div class="ch-alert__content">
         <div role="alert" aria-live="polite">
-          <slot />
+          <slot v-bind="{ content }" />
         </div>
-        <slot name="icon" />
+        <slot name="icon" v-bind="{ content }" />
       </div>
       <div v-if="$slots.footer" class="ch-alert__footer">
-        <slot name="footer" />
+        <slot name="footer" v-bind="{ content }" />
       </div>
     </div>
   </Transition>
@@ -30,10 +30,12 @@ const props = defineProps({
 })
 
 const timeoutId = ref()
+const content = ref()
 
 const isVisible = ref(false)
-const show = () => {
+const show = (alertContent?: unknown) => {
   isVisible.value = true
+  content.value = alertContent
   if (!props.persistent) {
     timeoutId.value = setTimeout(hide, props.duration)
   }


### PR DESCRIPTION
## ChAlert

### Проблема
При использовании ChAlert с динамическим текстом (валидационные сообщения, например) приходилось записывать текущее сообщение в переменную и передавать ее в template, чтобы было не очень удобно

```html
<template>
  <form @submit="onSubmit"></form>
  <ChAlert ref="alertRef">
    {{ validationMessage }}
  </ChAlert>
<template>

<script setup>
  const getValidationErrors = (): string[] => { ... };
  const validationMessage = ref()  

  const onSubmit = () => {
    const errors = getValidationErrors();
    if (errors) {
       validationMessage.value = errors[0]
       alertRef.show()
    }
  }
</script>
```

### Решение
При открытии ChAlert передавать в него контент, который будет доступен через scoped slot, чтобы не создавать отдельную переменную

```html
<template>
  <form @submit="onSubmit"></form>
  <ChAlert ref="alertRef">
    <template #default="{ content }">
      {{ content }}
    </template>
  </ChAlert>
<template>

<script setup>
  const getValidationErrors = (): string[] => { ... };
  const validationMessage = ref()  

  const onSubmit = () => {
    const errors = getValidationErrors();
    if (errors) {
       alertRef.show(errors[0])
    }
  }
</script>
```

- Добавил логику передачи контента в метод show

Resolves #96 

@raiymbekB 