### PR TITLE
Баг со скроллом в компоненте ChBottomSheet

### DIFF
--- a/src/components/ChBottomSheet/ChBottomSheet.vue
+++ b/src/components/ChBottomSheet/ChBottomSheet.vue
@@ -10,7 +10,6 @@
         data-test-id="bottom-sheet-blackout"
         @touchstart="onBlackoutTouchStart"
         @touchend="onBlackoutTouchEnd"
-        @click="hide"
       ></div>
       <div class="bottom-sheet">
         <div


### PR DESCRIPTION
Исправил баг со скроллом, который возникал из-за двойного вызова функции, блочащей скролл.
При нажатии на затемненный участок выше шторки ивент обрабатывался дважды - ontouchend, click. Там и там вызывался метод hide, который использует lock из tua-body-scroll-lock.
Внутри tua-body-scroll-lock есть счетчик открытых шторок, который нужен для логики с блоком скролла. Из-за неправильной обработки событий, счетчик неправильно отрабатывал и скролл ломался.