### PR TITLE
Баг со скроллом в компоненте ChBottomSheet

### DIFF
--- a/src/components/ChBottomSheet/ChBottomSheet.vue
+++ b/src/components/ChBottomSheet/ChBottomSheet.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, inject, watch, onBeforeUnmount } from 'vue'
+import { ref, inject, watch, onUnmounted } from 'vue'
 
 import { injectionKey } from './plugin/injection-key.config'
 import type { ModalBottomSheetController } from '@/composable/modal-bottom-sheet-controller/use-modal-bottom-sheet-controller'
@@ -91,7 +91,7 @@ if (controller) {
   })
 }
 
-onBeforeUnmount(() => controller?.onDestroy(props.name))
+onUnmounted(() => controller?.onDestroy(props.name))
 
 const onBlackoutTouchStart = () => (bottomSheetState.value.blackoutTouchStarted = true)
 


### PR DESCRIPTION
Есть еще один баг, связанный со скроллом. Внутри шторки есть обработка onBeforeUnmount - вызывается clearAllLocks из tua-body-scroll-lock. Этот метод сбрасывается состояние счетчика открытых модалок и шторок. Он должен вызываться в конце, но сейчас вызывается перед вызовом метода hide. Это ломает скролл.