### PR TITLE
ChCarousel: fix wrong injection names and add types

### DIFF
--- a/src/components/ChCarousel/ChCarouselBullets.spec.ts
+++ b/src/components/ChCarousel/ChCarouselBullets.spec.ts
@@ -9,6 +9,8 @@ const getWrapper = (numberOfSlides: number) =>
   mount(ChCarouselBullets, {
     global: {
       provide: {
+        // Ignore intentionally since TS does not allow to use InjectionKey as a keys
+        // @ts-ignore
         [carouselConfig.numberOfSlidesInjectionKey]: numberOfSlides
       }
     }

--- a/src/components/ChCarousel/ChCarouselBullets.vue
+++ b/src/components/ChCarousel/ChCarouselBullets.vue
@@ -5,11 +5,11 @@
     data-test-id="carousel-bullets-container"
   >
     <button
-      v-for="i in numberOfSlides"
+      v-for="i in numberOfSlides || 0"
       :key="i"
       class="glide__bullet ch-carousel__bullet"
       :data-glide-dir="`=${i - 1}`"
-      :aria-current="isActive(i)"
+      :aria-current="isActive(i - 1)"
       data-test-id="carousel-bullets"
     >
       <span class="ch-carousel__bullet-dot"></span>
@@ -19,12 +19,11 @@
 
 <script setup lang="ts">
 import { inject } from 'vue'
-import type Glide from '@glidejs/glide'
 import { carouselConfig } from './config'
 
-const glider = inject<Glide.Properties>(carouselConfig.gliderInjectionKey)
-const numberOfSlides = inject<number[]>(carouselConfig.numberOfSlidesInjectionKey) || 0
-const isActive = (idx: number) => idx === glider?.index
+const glider = inject(carouselConfig.gliderInjectionKey)
+const numberOfSlides = inject(carouselConfig.numberOfSlidesInjectionKey)
+const isActive = (idx: number) => idx === glider?.value?.index
 </script>
 
 <script lang="ts">

--- a/src/components/ChCarousel/config.ts
+++ b/src/components/ChCarousel/config.ts
@@ -1,4 +1,7 @@
-const gliderInjectionKey = 'ch-slider:glider'
-const numberOfSlidesInjectionKey = 'ch-slider:glider'
+import type { InjectionKey, Ref } from 'vue'
+import type Glide from '@glidejs/glide'
+
+const gliderInjectionKey = Symbol('ch-slider:glider') as InjectionKey<Ref<Glide.Properties>>
+const numberOfSlidesInjectionKey = Symbol('ch-slider:number-of-slides') as InjectionKey<Ref<number>>
 
 export const carouselConfig = { gliderInjectionKey, numberOfSlidesInjectionKey }


### PR DESCRIPTION
### ChCarousel

- Ключи с названием разных инъекций были одинаковые
- Добавили типизированные provide/inject