### PR TITLE
Fix scroll lock/unlock bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "choco-ui",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "choco-ui",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-regular-svg-icons": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-ui",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "npm": "^8.11.0",
     "node": "^16.15.1"

--- a/src/components/ChBottomSheet/ChBottomSheet.vue
+++ b/src/components/ChBottomSheet/ChBottomSheet.vue
@@ -70,7 +70,7 @@ const emit = defineEmits(['onClose', 'onOpen', 'onSheetTouchEnd', 'onHandleBarCl
 
 const controllerInjectionKey = inject<string>(injectionKey) as string
 const controller = inject<ModalBottomSheetController>(controllerInjectionKey)
-const bottomSheetRef = ref()
+const bottomSheetRef = ref<HTMLElement>()
 const contentRef = ref()
 const bottomSheetState = ref({
   blackoutTouchStarted: false,
@@ -124,7 +124,11 @@ const onSheetTouchMove = (e: TouchEvent) => {
 }
 
 const onSheetTouchEnd = () => {
-  const bottomSheetHeight = (bottomSheetRef.value as HTMLElement).offsetHeight
+  if (!bottomSheetRef.value) {
+    return
+  }
+
+  const bottomSheetHeight = bottomSheetRef.value.offsetHeight
   const closingLimit = bottomSheetHeight * 0.4
   if (
     bottomSheetState.value.sheetTouchStarted &&

--- a/src/components/ChSpinner/ChSpinner.spec.ts
+++ b/src/components/ChSpinner/ChSpinner.spec.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { shallowMount } from '@vue/test-utils'
+import type { VueWrapper } from '@vue/test-utils'
+
 import ChSpinner from './ChSpinner.vue'
 
 describe('ChSpinner', () => {
-  let wrapper: any = null
+  let wrapper: VueWrapper | null = null
 
   const createWrapper = (props: object = {}) => {
     const defaultProps: object = { size: 'base', box: false }
@@ -21,11 +23,11 @@ describe('ChSpinner', () => {
   it('renders properly with size', () => {
     const size = 'lg'
     createWrapper({ size })
-    expect(wrapper.classes()).toContain(`ch-spinner-container_${size}`)
+    expect(wrapper?.classes()).toContain(`ch-spinner-container_${size}`)
   })
 
   it('renders properly with box', () => {
     createWrapper({ box: true })
-    expect(wrapper.classes()).toContain('ch-spinner-container_box')
+    expect(wrapper?.classes()).toContain('ch-spinner-container_box')
   })
 })

--- a/src/components/ChToggleButtonGroup/ChToggleButtonGroup.stories.d.ts
+++ b/src/components/ChToggleButtonGroup/ChToggleButtonGroup.stories.d.ts
@@ -1,3 +1,3 @@
 export declare class WithLabel {
-  static args: any
+  static args: unknown
 }

--- a/src/composable/modal-bottom-sheet-controller/use-modal-bottom-sheet-controller.ts
+++ b/src/composable/modal-bottom-sheet-controller/use-modal-bottom-sheet-controller.ts
@@ -46,8 +46,14 @@ export function useModalBottomSheetController() {
   }
 
   function hide(name: string) {
-    unlockScroll(name)
-    state.value = state.value.filter(modal => modal.activeName !== name)
+    /**
+     * Need to unlock scroll the same time it was locked.
+     * Otherwise counter of locked scrolls goes to negative and on breaks on the next unlocks
+     */
+    if (isVisible(name)) {
+      unlockScroll(name)
+      state.value = state.value.filter(modal => modal.activeName !== name)
+    }
   }
 
   function onDestroy(name: string) {

--- a/src/composable/modal-bottom-sheet-controller/use-modal-bottom-sheet-controller.ts
+++ b/src/composable/modal-bottom-sheet-controller/use-modal-bottom-sheet-controller.ts
@@ -48,7 +48,7 @@ export function useModalBottomSheetController() {
   function hide(name: string) {
     /**
      * Need to unlock scroll the same time it was locked.
-     * Otherwise counter of locked scrolls goes to negative and on breaks on the next unlocks
+     * Otherwise counter of locked scrolls goes to negative and breaks on the next unlocks
      */
     if (isVisible(name)) {
       unlockScroll(name)


### PR DESCRIPTION
## Проблема
На андроид устройствах возникал баг при открытии нескольких шторок. Если нажимать много раз при закрытии шторки каждый раз вызывался метод `unlock` для разблокировки скролла. Похоже, из-за того, что он вызывался много раз скролл при следующем открытии ломался

## Решение
Вызываем метод hide только если шторка/модальное окно открыто (isVisible), чтобы избежать лишних вызовов `unlock`

## Дополнительно
- Исправил ошибку в консоли, которая тоже возникала при клике на закрывающуюся шторку. Добавил проверку на ее наличие
- Исправил warnings в консоли при запуске lint и typecheck