### PR TITLE
fix(ChBottomSheet): prevent default event behaviour only when bs is s…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "choco-ui",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "choco-ui",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-regular-svg-icons": "^6.1.1",
@@ -44,7 +44,7 @@
         "prettier": "^2.5.1",
         "sass": "^1.51.0",
         "typescript": "~4.6.3",
-        "vite": "^2.9.5",
+        "vite": "^2.9.16",
         "vite-plugin-dts": "^1.2.0",
         "vitest": "^0.9.3",
         "vue": "^3.2.37",
@@ -18871,9 +18871,15 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -19972,9 +19978,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-      "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+      "version": "8.4.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
+      "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
       "funding": [
         {
           "type": "opencollective",
@@ -19983,10 +19989,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.1",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -24507,15 +24517,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.6.tgz",
-      "integrity": "sha512-3IffdrByHW95Yjv0a13TQOQfJs7L5dVlSPuTt432XLbRMriWbThqJN2k/IS6kXn5WY4xBLhK9XoaWay1B8VzUw==",
+      "version": "2.9.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
+      "integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.27",
-        "postcss": "^8.4.12",
+        "postcss": "^8.4.13",
         "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "rollup": ">=2.59.0 <2.78.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -40976,9 +40986,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w=="
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -41864,11 +41874,11 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-      "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+      "version": "8.4.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
+      "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
       "requires": {
-        "nanoid": "^3.3.1",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -45457,16 +45467,16 @@
       }
     },
     "vite": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.6.tgz",
-      "integrity": "sha512-3IffdrByHW95Yjv0a13TQOQfJs7L5dVlSPuTt432XLbRMriWbThqJN2k/IS6kXn5WY4xBLhK9XoaWay1B8VzUw==",
+      "version": "2.9.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
+      "integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.12",
+        "postcss": "^8.4.13",
         "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "rollup": ">=2.59.0 <2.78.0"
       }
     },
     "vite-plugin-dts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choco-ui",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "engines": {
     "npm": "^8.11.0",
     "node": "^16.15.1"
@@ -70,7 +70,7 @@
     "prettier": "^2.5.1",
     "sass": "^1.51.0",
     "typescript": "~4.6.3",
-    "vite": "^2.9.5",
+    "vite": "^2.9.16",
     "vite-plugin-dts": "^1.2.0",
     "vitest": "^0.9.3",
     "vue": "^3.2.37",

--- a/src/components/ChBottomSheet/ChBottomSheet.vue
+++ b/src/components/ChBottomSheet/ChBottomSheet.vue
@@ -8,7 +8,7 @@
       <div
         class="bottom-sheet-container__blackout"
         data-test-id="bottom-sheet-blackout"
-        @touchstart.stop="onBlackoutTouchStart"
+        @touchstart.prevent="onBlackoutTouchStart"
         @touchend="onBlackoutTouchEnd"
       ></div>
       <div class="bottom-sheet">
@@ -21,9 +21,9 @@
         >
           <div
             data-test-id="bottom-sheet-header-with-handle"
-            @touchstart.stop="onSheetTouchStart"
-            @touchmove.stop="onSheetTouchMove"
-            @touchend.stop="onSheetTouchEnd"
+            @touchstart="onSheetTouchStart"
+            @touchmove="onSheetTouchMove"
+            @touchend="onSheetTouchEnd"
           >
             <div
               class="bottom-sheet__handle-bar-container"
@@ -44,7 +44,7 @@
             class="bottom-sheet__body"
             data-test-id="bottom-sheet-content"
             :data-preserve-scroll="name"
-            @touchstart.stop="onContentTouchStart"
+            @touchstart="onContentTouchStart"
             @touchmove="onSheetTouchMove"
             @touchend="onSheetTouchEnd"
           >
@@ -134,6 +134,14 @@ const onSheetTouchMove = (e: TouchEvent) => {
   if (bottomSheetState.value.sheetTouchStarted) {
     const shift = extractTouch(e) - bottomSheetState.value.sheetTouchStart
     bottomSheetState.value.sheetShift = Math.max(0, shift)
+
+    /**
+     * should prevent default behaviour only when bottom sheet starts to shift
+     * otherwise other scrollable children elements won't work
+     */
+    if (shift > 0) {
+      e.preventDefault()
+    }
   }
 }
 


### PR DESCRIPTION
### Проблема

При закрытии шторки событие `touchmove` срабатывало на элементах, поверх которых была открыта шторка. Поэтому при закрытии шторки можно было отлавливать моменты, когда фон сразу же начинал скроллиться после закрытия шторки.

### Решение

Останавливаю дефолтное поведение `touchmove` из шторки, чтобы оно не пробрасывалось дальше в родителя. При этом остановка идет только когда происходит `shift` шторки, чтобы не ломать функционал элементов у которых есть скролл внутри шторки
